### PR TITLE
Modified ignition and cv variables for Noetic/focal

### DIFF
--- a/uuv_control/uuv_thruster_manager/src/uuv_thrusters/models/thruster_proportional.py
+++ b/uuv_control/uuv_thruster_manager/src/uuv_thrusters/models/thruster_proportional.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import rospy
 import numpy
-from thruster import Thruster
+from .thruster import Thruster
 
 
 class ThrusterProportional(Thruster):

--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/CMakeLists.txt
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(uuv_gazebo_plugins)
 
-# Specify C++11 standard
-add_definitions(-std=c++11)
+# Specify C++17 standard
+add_definitions(-std=c++17)
 
 find_package(catkin REQUIRED COMPONENTS
     gazebo_dev)

--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/include/uuv_gazebo_plugins/BuoyantObject.hh
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/include/uuv_gazebo_plugins/BuoyantObject.hh
@@ -74,7 +74,7 @@ class BuoyantObject
   public: double GetGravity();
 
   /// \brief Sets bounding box
-  public: void SetBoundingBox(const ignition::math::Box &_bBox);
+  public: void SetBoundingBox(const ignition::math::AxisAlignedBox &_bBox);
 
   /// \brief Adds a field in the hydroWrench map
   public: void SetStoreVector(std::string _tag);
@@ -120,7 +120,7 @@ class BuoyantObject
 
   /// \brief TEMP for calculation of the buoyancy
   /// force close to the surface
-  protected: ignition::math::Box boundingBox;
+  protected: ignition::math::AxisAlignedBox boundingBox;
 
   /// \brief Storage for hydrodynamic and hydrostatic forces and torques
   /// for debugging purposes

--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/include/uuv_gazebo_plugins/BuoyantObject.hh
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/include/uuv_gazebo_plugins/BuoyantObject.hh
@@ -35,6 +35,15 @@ namespace gazebo
 /// representations of underwater structures
 class BuoyantObject
 {
+  /// \brief Sets bounding box
+#if GAZEBO_MAJOR_VERSION >= 11
+    public: void SetBoundingBox(const ignition::math::AxisAlignedBox &_bBox);
+    protected: ignition::math::AxisAlignedBox boundingBox;
+#else
+    public: void SetBoundingBox(const ignition::math::Box &_bBox);
+    protected: ignition::math::Box boundingBox;
+#endif
+
   /// \brief Constructor
   public: BuoyantObject(physics::LinkPtr _link);
 
@@ -72,9 +81,6 @@ class BuoyantObject
 
   /// \brief Get stored acceleration of gravity
   public: double GetGravity();
-
-  /// \brief Sets bounding box
-  public: void SetBoundingBox(const ignition::math::AxisAlignedBox &_bBox);
 
   /// \brief Adds a field in the hydroWrench map
   public: void SetStoreVector(std::string _tag);
@@ -117,10 +123,6 @@ class BuoyantObject
 
   /// \brief Center of buoyancy in the body frame
   protected: ignition::math::Vector3d centerOfBuoyancy;
-
-  /// \brief TEMP for calculation of the buoyancy
-  /// force close to the surface
-  protected: ignition::math::AxisAlignedBox boundingBox;
 
   /// \brief Storage for hydrodynamic and hydrostatic forces and torques
   /// for debugging purposes

--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/src/BuoyantObject.cc
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/src/BuoyantObject.cc
@@ -205,9 +205,9 @@ void BuoyantObject::ApplyBuoyancyForce()
 }
 
 /////////////////////////////////////////////////
-void BuoyantObject::SetBoundingBox(const ignition::math::Box &_bBox)
+void BuoyantObject::SetBoundingBox(const ignition::math::AxisAlignedBox &_bBox)
 {
-  this->boundingBox = ignition::math::Box(_bBox);
+  this->boundingBox = ignition::math::AxisAlignedBox(_bBox);
 
   gzmsg << "New bounding box for " << this->link->GetName() << "::"
     << this->boundingBox << std::endl;

--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/src/BuoyantObject.cc
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/src/BuoyantObject.cc
@@ -205,14 +205,23 @@ void BuoyantObject::ApplyBuoyancyForce()
 }
 
 /////////////////////////////////////////////////
-void BuoyantObject::SetBoundingBox(const ignition::math::AxisAlignedBox &_bBox)
-{
-  this->boundingBox = ignition::math::AxisAlignedBox(_bBox);
+#if GAZEBO_MAJOR_VERSION >= 11
+  void BuoyantObject::SetBoundingBox(const ignition::math::AxisAlignedBox &_bBox)
+  {
+    this->boundingBox = ignition::math::AxisAlignedBox(_bBox);
 
-  gzmsg << "New bounding box for " << this->link->GetName() << "::"
-    << this->boundingBox << std::endl;
-}
+    gzmsg << "New bounding box for " << this->link->GetName() << "::"
+      << this->boundingBox << std::endl;
+  }
+#else
+  void BuoyantObject::SetBoundingBox(const ignition::math::Box &_bBox)
+  {
+    this->boundingBox = ignition::math::Box(_bBox);
 
+    gzmsg << "New bounding box for " << this->link->GetName() << "::"
+          << this->boundingBox << std::endl;
+  }
+#endif
 /////////////////////////////////////////////////
 void BuoyantObject::SetVolume(double _volume)
 {

--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/src/HydrodynamicModel.cc
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/src/HydrodynamicModel.cc
@@ -75,10 +75,19 @@ HydrodynamicModel::HydrodynamicModel(sdf::ElementPtr _sdf,
       double width = sdfModel->Get<double>("width");
       double length = sdfModel->Get<double>("length");
       double height = sdfModel->Get<double>("height");
-        ignition::math::AxisAlignedBox boundingBox = ignition::math::AxisAlignedBox(
+#if GAZEBO_MAJOR_VERSION >= 11
+      ignition::math::AxisAlignedBox boundingBox = ignition::math::AxisAlignedBox(
         ignition::math::Vector3d(-width / 2, -length / 2, -height / 2),
         ignition::math::Vector3d(width / 2, length / 2, height / 2));
-        this->SetBoundingBox(boundingBox);
+      this->SetBoundingBox(boundingBox);
+
+#else
+      ignition::math::Box boundingBox = ignition::math::Box(
+        ignition::math::Vector3d(-width / 2, -length / 2, -height / 2),
+        ignition::math::Vector3d(width / 2, length / 2, height / 2));
+      // Setting the the bounding box from the given dimensions
+      this->SetBoundingBox(boundingBox);
+#endif
     }
   }
 

--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/src/HydrodynamicModel.cc
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/src/HydrodynamicModel.cc
@@ -75,11 +75,10 @@ HydrodynamicModel::HydrodynamicModel(sdf::ElementPtr _sdf,
       double width = sdfModel->Get<double>("width");
       double length = sdfModel->Get<double>("length");
       double height = sdfModel->Get<double>("height");
-      ignition::math::Box boundingBox = ignition::math::Box(
+        ignition::math::AxisAlignedBox boundingBox = ignition::math::AxisAlignedBox(
         ignition::math::Vector3d(-width / 2, -length / 2, -height / 2),
         ignition::math::Vector3d(width / 2, length / 2, height / 2));
-      // Setting the the bounding box from the given dimensions
-      this->SetBoundingBox(boundingBox);
+        this->SetBoundingBox(boundingBox);
     }
   }
 

--- a/uuv_sensor_plugins/uuv_sensor_ros_plugins/src/gazebo_ros_image_sonar.cpp
+++ b/uuv_sensor_plugins/uuv_sensor_ros_plugins/src/gazebo_ros_image_sonar.cpp
@@ -942,9 +942,9 @@ cv::Mat GazeboRosImageSonar::ConstructVisualScanImage(cv::Mat& raw_scan)
   cv::Scalar white(255, 255, 255);
   cv::Size axes1(2./3.*scan.rows, 2./3.*scan.rows);
   cv::Size axes2(1./3.*scan.rows, 1./3.*scan.rows);
-  cv::ellipse(scan, center, axes, -90, -fov/2.-0.5, fov/2., white, 1, CV_AA); //, int lineType=LINE_8, 0);
-  cv::ellipse(scan, center, axes1, -90, -fov/2., fov/2., white, 1, CV_AA); //, int lineType=LINE_8, 0);
-  cv::ellipse(scan, center, axes2, -90, -fov/2., fov/2., white, 1, CV_AA); //, int lineType=LINE_8, 0);
+  cv::ellipse(scan, center, axes, -90, -fov/2.-0.5, fov/2., white, 1, CV_AVX); //, int lineType=LINE_8, 0);
+  cv::ellipse(scan, center, axes1, -90, -fov/2., fov/2., white, 1, CV_AVX); //, int lineType=LINE_8, 0);
+  cv::ellipse(scan, center, axes2, -90, -fov/2., fov/2., white, 1, CV_AVX); //, int lineType=LINE_8, 0);
 
   for (int i = 0; i < 5; ++i) {
     float angle = -fov/2.-0.5 + (fov+0.5)*i/float(5-1);
@@ -955,7 +955,7 @@ cv::Mat GazeboRosImageSonar::ConstructVisualScanImage(cv::Mat& raw_scan)
     cv::Point corner(scan.cols/2+cornerx, scan.rows-cornery); 
     //cv::line(scan, center, left_corner, white, 2);
     //cv::line(scan, center, right_corner, white, 2);
-    cv::line(scan, center, corner, white, 1, CV_AA);
+    cv::line(scan, center, corner, white, 1, CV_AVX);
   }
   
   cv_bridge::CvImage img_bridge;


### PR DESCRIPTION
Updated ignition and opencv variables to compile with Neotic/Focal/Gazebo11. Currently compiles, but python scripts are not found and thrusters fail.

Currently going through the migration guide