### PR TITLE
tf fix and added missing function returns

### DIFF
--- a/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/src/UnderwaterObjectROSPlugin.cc
+++ b/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/src/UnderwaterObjectROSPlugin.cc
@@ -203,9 +203,11 @@ void UnderwaterObjectROSPlugin::Reset()
 void UnderwaterObjectROSPlugin::Update(const gazebo::common::UpdateInfo &_info)
 {
   UnderwaterObjectPlugin::Update(_info);
-
-  this->nedTransform.header.stamp = ros::Time::now();
-  this->tfBroadcaster.sendTransform(this->nedTransform);
+  if (ros::Time::now() != this->nedTransform.header.stamp)
+  {
+    this->nedTransform.header.stamp = ros::Time::now();
+    this->tfBroadcaster.sendTransform(this->nedTransform);
+  }
 }
 
 /////////////////////////////////////////////////

--- a/uuv_sensor_plugins/uuv_sensor_ros_plugins/src/MagnetometerROSPlugin.cc
+++ b/uuv_sensor_plugins/uuv_sensor_ros_plugins/src/MagnetometerROSPlugin.cc
@@ -149,6 +149,7 @@ bool MagnetometerROSPlugin::OnUpdate(const common::UpdateInfo& _info)
   this->rosMsg.magnetic_field.z = this->measMagneticField.Z();
 
   this->rosSensorOutputPub.publish(this->rosMsg);
+  return true;
 }
 
 /////////////////////////////////////////////////

--- a/uuv_sensor_plugins/uuv_sensor_ros_plugins/src/ROSBasePlugin.cc
+++ b/uuv_sensor_plugins/uuv_sensor_ros_plugins/src/ROSBasePlugin.cc
@@ -141,6 +141,7 @@ bool ROSBasePlugin::InitBasePlugin(sdf::ElementPtr _sdf)
 
   // Add a default Gaussian noise model
   this->AddNoiseModel("default", this->noiseSigma);
+  return true;
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
This PR fixes two issues we were encountering with the dave_demo launch. 

1. Stops the following tf output by checking that duplicate timestamps aren't broadcasted 

```
[ WARN] [1629930410.907907958, 0.550000000]: TF_REPEATED_DATA ignoring data with redundant timestamp for frame rexrov/base_link_ned at time 0.548000 according to authority unknown_publisher
Warning: TF_REPEATED_DATA ignoring data with redundant timestamp for frame rexrov/base_link_ned at time 0.548000 according to authority /gazebo
         at line 278 in /tmp/binarydeb/ros-noetic-tf2-0.7.5/src/buffer_core.cpp
```

2. Adds missing function returns that were crashing the simulator in 20.04 noetic when using `catkin build` and `clang`

