### PR TITLE
Adding SDF version to model config

### DIFF
--- a/uuv_gazebo_worlds/models/ned_frame/model.config
+++ b/uuv_gazebo_worlds/models/ned_frame/model.config
@@ -8,7 +8,7 @@
 <model>
   <name>NED frame</name>
   <version>0.0.1</version>
-  <sdf  version='1.6'>model.sdf</sdf>
+  <sdf version='1.6'>model.sdf</sdf>
   <author>
     <name>Musa Marcusso</name>
     <email>musa.marcusso@de.bosch.com</email>

--- a/uuv_gazebo_worlds/models/ned_frame/model.config
+++ b/uuv_gazebo_worlds/models/ned_frame/model.config
@@ -8,7 +8,7 @@
 <model>
   <name>NED frame</name>
   <version>0.0.1</version>
-  <sdf>model.sdf</sdf>
+  <sdf  version='1.6'>model.sdf</sdf>
   <author>
     <name>Musa Marcusso</name>
     <email>musa.marcusso@de.bosch.com</email>


### PR DESCRIPTION
Issue

When running examples such as `roslaunch dave_demo_launch dave_demo.launch` the user receives a warning ...

```
Warning [parser.cc:723] Can not find the XML attribute 'version' in sdf XML tag for model: NED frame. Please specify the SDF protocol supported in the model configuration file. The first sdf tag in the config file will be used 
```

This PR adds the version to the SDF tag in the model.config file to eliminate the warning.
